### PR TITLE
Share one namespace across devices on the Conductor dev server

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -5,7 +5,10 @@ setup = "bundle install"
 run_mode = "concurrent"
 
 [scripts.run.dev]
-command = "bundle exec rackup -p $CONDUCTOR_PORT"
+# DLCENTER_COMMON_CONTEXT: all clients in one namespace, so a phone on the
+# LAN and the browser on localhost see each other's shares
+# -o 0.0.0.0: let that phone reach the dev server at all
+command = "DLCENTER_COMMON_CONTEXT=1 bundle exec rackup -o 0.0.0.0 -p $CONDUCTOR_PORT"
 available_in = [ "local" ]
 default = true
 icon = "play"


### PR DESCRIPTION
Run the Conductor dev script with `DLCENTER_COMMON_CONTEXT=1` so a phone on the
Wi-Fi and the browser on localhost land in the same namespace and see each
other's shares, instead of being isolated by their different IPs. The env var
already existed, this just wires it into the dev run script.

`-o 0.0.0.0` as well: rackup only listens on localhost in development, so the
phone could not reach the dev server at all.

Only `.conductor/settings.toml` changes — no application behaviour is affected.